### PR TITLE
Add devmode engine block signer comparison

### DIFF
--- a/sdk/rust/src/consensus/engine.rs
+++ b/sdk/rust/src/consensus/engine.rs
@@ -32,7 +32,7 @@ pub enum Update {
     BlockCommit(BlockId),
 }
 
-#[derive(Clone, Default, Debug)]
+#[derive(Clone, Default, Debug, PartialEq, PartialOrd)]
 pub struct BlockId(Vec<u8>);
 impl Deref for BlockId {
     type Target = Vec<u8>;


### PR DESCRIPTION
Previously when choosing between two chains with the same height, the
engine would simply stay with its current chain. But if every node
followed this strategy, then barring fortuitous timing, the network
would fork.

Signed-off-by: Nick Drozd <drozd@bitwise.io>